### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,6 +9,8 @@ jobs:
   deploy:
     name: Deploy to Reflex Cloud
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/sapphireUI/SapphireUI/security/code-scanning/2](https://github.com/sapphireUI/SapphireUI/security/code-scanning/2)

To fix this issue, you should add a `permissions:` key specifying least privilege at either the workflow root (applies to all jobs unless overridden per job) or at the affected job—here, at the job level under `deploy:` (or at the top level if the entire workflow is single-job). For most deploy workflows where no git operations or PR manipulations occur, `contents: read` is a safe minimal permission. Thus, you should add a permissions block with `contents: read` under the `deploy:` job. Edit `.github/workflows/deploy.yml` to add this directly under `runs-on:`.

You do not need any imports, new methods, or variable definitions: the change is the addition of the required permissions block.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
