### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -1,4 +1,6 @@
 name: Development Preview
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/sapphireUI/SapphireUI/security/code-scanning/1](https://github.com/sapphireUI/SapphireUI/security/code-scanning/1)

To fix the problem, add a `permissions` key specifying the minimal required privileges for the workflow. Since the provided workflow seems only to read the repository's code during checkout and does not update repository contents, issues, or pull requests, the minimal needed permission is `contents: read`. This should be added at the top level of the workflow file, just below the `name` key (before `on:`), or at the job level if different jobs require different permissions. Adding it at the workflow level ensures all jobs default to these least-privilege settings unless individually overridden. 

No changes are needed to imports or any internal method/variable definitions, since this is a YAML configuration for GitHub Actions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
